### PR TITLE
Use amx_NameLength to get max public name length.

### DIFF
--- a/src/Functions.h
+++ b/src/Functions.h
@@ -181,9 +181,12 @@ namespace Functions {
     }
 
     std::string GetAmxPublicName(AMX *amx, int index) {
-        int length;
-        amx_NameLength(_amx, &length);
-        std::unique_ptr<char[]> public_name(new char[length]);
+        int len{};
+        if (amx_NameLength(amx, &len) != AMX_ERR_NONE) {
+            throw std::runtime_error{"name length error"};
+        }
+
+        std::unique_ptr<char[]> name{new char[len + 1]{}};
 
         if (amx_GetPublic(amx, index, name.get()) != AMX_ERR_NONE) {
             throw std::runtime_error{"invalid public index"};

--- a/src/Functions.h
+++ b/src/Functions.h
@@ -181,13 +181,15 @@ namespace Functions {
     }
 
     std::string GetAmxPublicName(AMX *amx, int index) {
-        char name[32]{};
+        int length;
+        amx_NameLength(_amx, &length);
+        std::unique_ptr<char[]> public_name(new char[length]);
 
-        if (amx_GetPublic(amx, index, name) != AMX_ERR_NONE) {
+        if (amx_GetPublic(amx, index, name.get()) != AMX_ERR_NONE) {
             throw std::runtime_error{"invalid public index"};
         }
 
-        return name;
+        return name.get();
     }
 
     cell & GetAmxParamRef(AMX *amx, cell amx_addr) {


### PR DESCRIPTION
Plugins like [LFN](https://github.com/IllidanS4/LFN) and other compilers can have function names of different sizes. This change is to get the max name length of the script and use that to create a buffer big enough to get the public function name.