### PR TITLE
Use samp exposed RakServer handle instead of pattern scanning 

### DIFF
--- a/src/hooks.cc
+++ b/src/hooks.cc
@@ -229,18 +229,6 @@ void Hooks::HandleRPC(RPCIndex rpc_id, RPCParameters *p) {
   }
 }
 
-urmem::address_t Hooks::GetRakServerInterface() {
-  auto &plugin = Plugin::Get();
-
-  const auto addr_rakserver =
-      plugin.GetHookGetRakServerInterface()
-          ->call<urmem::calling_convention::cdeclcall, urmem::address_t>();
-
-  plugin.InstallRakServerHooks(addr_rakserver);
-
-  return addr_rakserver;
-}
-
 int AMXAPI Hooks::amx_Cleanup(AMX *amx) {
   auto &plugin = Plugin::Get();
 

--- a/src/hooks.h
+++ b/src/hooks.h
@@ -72,8 +72,6 @@ class Hooks {
 
   static void HandleRPC(RPCIndex rpc_id, RPCParameters *p);
 
-  static urmem::address_t GetRakServerInterface();
-
   static int AMXAPI amx_Cleanup(AMX *amx);
 };
 

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -158,8 +158,19 @@ void Plugin::InstallRakServerHooks(urmem::address_t addr_rakserver) {
 }
 
 unsigned char Plugin::GetPacketId(Packet *packet) {
-  return urmem::call_function<urmem::calling_convention::cdeclcall,
-                              unsigned char>(addr_get_packet_id_, packet);
+  if (packet == 0) {
+    return 255;
+  }
+
+  unsigned char id = static_cast<unsigned char>(packet->data[0]);
+
+  // ID_TIMESTAMP = 40
+  if (id == 40) {
+    return static_cast<unsigned char>(packet->data[5]);
+  }
+  else {
+    return id;
+  }
 }
 
 Packet *Plugin::NewPacket(PlayerIndex index, const BitStream &bs) {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -57,8 +57,6 @@ class Plugin : public ptl::AbstractPlugin<Plugin, Script, NativeParam> {
 
   RPCFunction GetFakeRPCHandler(RPCIndex rpc_id);
 
-  const std::shared_ptr<urmem::hook> &GetHookGetRakServerInterface();
-
   const std::shared_ptr<urmem::hook> &GetHookAmxCleanup();
 
   const std::shared_ptr<Config> &GetConfig();
@@ -79,44 +77,14 @@ class Plugin : public ptl::AbstractPlugin<Plugin, Script, NativeParam> {
   static Plugin &Get() { return Instance(); }
 
  private:
-#ifdef _WIN32
-  const char *get_rakserver_interface_pattern_ =
-      "\x6A\xFF\x68\x5B\xA4\x4A\x00\x64\xA1\x00\x00"
-      "\x00\x00\x50\x64\x89\x25\x00\x00\x00\x00\x51"
-      "\x68\x18\x0E\x00\x00\xE8\xFF\xFF\xFF\xFF\x83"
-      "\xC4\x04\x89\x04\x24\x85\xC0\xC7\x44\x24\xFF"
-      "\x00\x00\x00\x00\x74\x16";
-  const char *get_rakserver_interface_mask_ =
-      "???????xxxxxxxxxxxxxxxx????x????xxxxxxxxxxx?xxxxxx";
 
-  const char *get_packet_id_pattern_ =
-      "\x8B\x44\x24\x04\x85\xC0\x75\x03\x0C\xFF\xC3\x8B\x48\x10\x8A\x01"
-      "\x3C\xFF\x75\x03\x8A\x41\x05\xC3";
-  const char *get_packet_id_mask_ = "?????xxxxxxxxxxxx?xxxxxx";
-#else
-  const char *get_rakserver_interface_pattern_ =
-      "\x55\x89\xE5\x83\xEC\x18\xC7\x04\x24\xFF\xFF"
-      "\xFF\xFF\x89\x75\xFF\x89\x5D\xFF\xE8\xFF\xFF"
-      "\xFF\xFF\x89\x04\x24\x89\xC6\xE8\xFF\xFF\xFF"
-      "\xFF\x89\xF0\x8B\x5D\xFF\x8B\x75\xFF\x89\xEC"
-      "\x5D\xC3";
-  const char *get_rakserver_interface_mask_ =
-      "?????xxxx????xx?xx?x????xxxxxx????xxxx?xx?xxxx";
-
-  const char *get_packet_id_pattern_ =
-      "\x55\xB8\xFF\x00\x00\x00\x89\xE5\x8B\x55\x08\x85\xD2\x74\x0D\x8B"
-      "\x52\x10\x0F\xB6\x02\x3C\xFF\x74\x07\x0F\xB6\xC0\x5D\xC3\x66\x90"
-      "\x0F\xB6\x42\x05\x5D\xC3";
-  const char *get_packet_id_mask_ = "?????xxxxxxxxxxxxxxxxx?xxxxxxxxxxxxxxx";
-#endif
+ private:
+  bool initialized_hooks_ = false;
 
   std::shared_ptr<Config> config_;
 
-  urmem::address_t addr_get_packet_id_{};
-
   std::shared_ptr<RakServer> rakserver_;
 
-  std::shared_ptr<urmem::hook> hook_get_rakserver_interface_;
   std::shared_ptr<urmem::hook> hook_amx_cleanup_;
 
   std::shared_ptr<PluginInterface> message_handler_;

--- a/src/script.cc
+++ b/src/script.cc
@@ -510,6 +510,8 @@ cell Script::BS_ReadValue(cell *params) {
 bool Script::OnLoad() {
   config_ = Plugin::Get().GetConfig();
 
+  Plugin::Get().InstallPreHooks();
+
   int num_publics{};
   amx_->NumPublics(&num_publics);
 


### PR DESCRIPTION
This PR uses passed plugin data from samp when plugin loads, which in index `0xE2` it holds an address to a function, that returns an instance of `RakServer`
So instead of doing pattern scanning and depending on specific samp versions, I'm using the one exposed by samp itself so there won't be a problem with using it in different versions

(and I'm also doing this since we might make pawn.raknet compatible with open.mp as well, our function signatures are slightly different so it's not possible right now)

if there's anything wrong with doing this, or there's any issues, please tell me