### PR TITLE
Add playerid being -1 validity check

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -82,11 +82,19 @@ void PluginComponent::onTick(Microseconds elapsed, TimePoint now) {
 
 bool PluginComponent::onReceivePacket(IPlayer &peer, int id,
                                       NetworkBitStream &bs) {
+  if (peer.getID() == -1) {
+    return true;
+  }
+
   return Plugin::OnEvent<PR_INCOMING_PACKET>(peer.getID(), id, &bs);
 }
 
 bool PluginComponent::onReceiveRPC(IPlayer &peer, int id,
                                    NetworkBitStream &bs) {
+  if (peer.getID() == -1) {
+    return true;
+  }
+
   auto &plugin = Plugin::Get();
 
   const auto on_event = plugin.IsCustomRPC(static_cast<RPCIndex>(id))


### PR DESCRIPTION
Apparently this was added in Pawn.RakNet 1.30 as a validity check in Here: https://github.com/katursis/Pawn.RakNet/commit/1aa8b9bb23c0825cf65e17e2a12b197f306abf5d but it's left out in open.mp port

Related issue: https://github.com/openmultiplayer/open.mp/issues/818